### PR TITLE
Always include dune and always exclude threads

### DIFF
--- a/index.ml
+++ b/index.ml
@@ -8,7 +8,7 @@ let update_index t changes ~pkg =
       match op with
       | OpamDirTrack.Added _ ->
         begin match String.split_on_char '/' file with
-          | "lib" :: lib :: _ -> Owner.add lib pkg acc
+          | ["lib"; lib; "META"] -> Owner.add lib pkg acc
           | _ -> acc
         end
       | _ -> acc

--- a/main.ml
+++ b/main.ml
@@ -34,6 +34,8 @@ let get_libraries ~pkg ~target =
       | _ -> None
     )
   |> Libraries.of_list
+  |> Libraries.remove "threads"         (* META file is provided by ocamlfind, but dune doesn't need it *)
+  |> Libraries.add "dune"               (* We always need dune *)
 
 let to_opam lib =
   let lib = Astring.String.take ~sat:((<>) '.') lib in


### PR DESCRIPTION
Any dune project should have a dependency on dune. Fixes #1.

Dune lists `threads` as an external library you need, even though in fact it has its own built-in version. So filter that out. Fixes #2.

Also, only consider a package as owning an ocamlfind library if it added the `META` file, not just if it added any file to its directory. Not sure if this makes any difference, but might be useful.