### PR TITLE
Add support for vendoring

### DIFF
--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
 (executable
  (public_name dune-opam-lint)
  (name main)
- (libraries fmt fmt.tty bos opam-format opam-state findlib dune-private-libs.dune-lang cmdliner))
+ (libraries astring fmt fmt.tty bos opam-format opam-state findlib dune-private-libs.dune-lang cmdliner sexplib))

--- a/dune-opam-lint.opam
+++ b/dune-opam-lint.opam
@@ -7,6 +7,8 @@ homepage: "https://github.com/talex5/dune-opam-lint"
 bug-reports: "https://github.com/talex5/dune-opam-lint/issues"
 depends: [
   "dune" {>= "2.7"}
+  "astring" {>= "0.8.5"}
+  "sexplib" {>= "v0.14.0"}
   "cmdliner" {>= "1.0.4"}
   "dune-private-libs" {>= "2.7.1"}
   "ocaml" {>= "4.11.0"}

--- a/dune-project
+++ b/dune-project
@@ -10,6 +10,8 @@
  (name dune-opam-lint)
  (synopsis "Ensure dune and opam dependencies are consistent")
  (depends
+  (astring (>= 0.8.5))
+  (sexplib (>= v0.14.0))
   (cmdliner (>= 1.0.4))
   (dune-private-libs (>= 2.7.1))
   (ocaml (>= 4.11.0))

--- a/dune_project.ml
+++ b/dune_project.ml
@@ -6,6 +6,10 @@ let atom = Dune_lang.atom
 let dune_and x y =  Dune_lang.(List [atom "and"; x; y])
 let lower_bound v = Dune_lang.(List [atom ">="; atom (OpamPackage.Version.to_string v)])
 
+let or_die = function
+  | Ok x -> x
+  | Error (`Msg m) -> failwith m
+
 let parse () =
   Stdune.Path.Build.(set_build_dir (Kind.of_string (Sys.getcwd ())));
   let path = Stdune.Path.of_string "dune-project" in
@@ -97,3 +101,117 @@ let write_project_file t =
   Fmt.pf f "@[<v>%a@]@." (Fmt.list ~sep:Fmt.cut (Fmt.using Dune_lang.pp Stdune.Pp.render_ignore_tags)) t;
   close_out ch;
   Fmt.pr "Wrote %S@." path
+
+module Deps = struct
+  (*  We use [tmp_dir] so that "--only-packages" doesn't invalidate the existing build. *)
+  let dune_external_lib_deps ~tmp_dir ~pkg ~target =
+    let tmp_dir = Fpath.to_string tmp_dir in
+    Bos.Cmd.(v "dune" % "external-lib-deps" % "--only-packages" % pkg
+             % "--build-dir" % tmp_dir
+             % "--sexp" % "--unstable-by-dir"
+             % target)
+
+  let has_dune_subproject = function
+    | "." | "" -> false
+    | dir -> Sys.file_exists (Filename.concat dir "dune-project")
+
+  let rec should_use_dir ~dir_types path =
+    match Hashtbl.find_opt dir_types path with
+    | Some x -> x
+    | None ->
+      let r =
+        match Astring.String.cut ~sep:"/" ~rev:true path with
+        | Some (parent, _) ->
+          if should_use_dir ~dir_types parent then (
+            not (has_dune_subproject path)
+          ) else false
+        | None ->
+          not (has_dune_subproject path)
+      in
+      Hashtbl.add dir_types path r;
+      r
+
+  let merge_dep acc = function
+    | Sexplib.Sexp.List (Atom lib :: _) -> Libraries.add lib acc
+    | x -> Fmt.failwith "Bad output from 'dune external-lib-deps': %a" Sexplib.Sexp.pp_hum x
+
+  let merge_dir ~dir_types acc = function
+    | Sexplib.Sexp.List [Atom path; List deps] ->
+      if should_use_dir ~dir_types path then (
+        (* Fmt.pr "Process %S@." path; *)
+        List.fold_left merge_dep acc deps
+      ) else (
+        (* Fmt.pr "Skip %S@." path; *)
+        acc
+      )
+    | x -> Fmt.failwith "Bad output from 'dune external-lib-deps': %a" Sexplib.Sexp.pp_hum x
+
+  let parse = function
+    | Sexplib.Sexp.List [Atom _ctx; List dirs] ->
+      let dir_types = Hashtbl.create 10 in
+      List.fold_left (merge_dir ~dir_types) Libraries.empty dirs
+    | x -> Fmt.failwith "Bad output from 'dune external-lib-deps': %a" Sexplib.Sexp.pp_hum x
+
+  (* Get the ocamlfind dependencies of [pkg]. *)
+  let get_external_lib_deps ~pkg ~target =
+    Bos.OS.Dir.with_tmp "dune-opam-lint-%s" (fun tmp_dir () ->
+        Bos.OS.Cmd.run_out (dune_external_lib_deps ~tmp_dir ~pkg ~target)
+        |> Bos.OS.Cmd.to_string
+        |> or_die
+      ) ()
+    |> or_die
+    |> String.trim
+    |> function
+    | "" -> Libraries.empty
+    | sexp -> parse (Sexplib.Sexp.of_string sexp)
+end
+
+module Csexp = struct
+  type t =
+    | Atom of string
+    | List of t list
+end
+
+module Sexp = Dune_csexp.Csexp.Make(Csexp)
+module Library_map = Map.Make(String)
+
+open Csexp
+
+type index = [`Internal | `External] Library_map.t
+
+let rec field name = function
+  | [] -> Fmt.failwith "Field %S is missing!" name
+  | List [Atom n; v] :: _ when n = name -> v
+  | _ :: xs -> field name xs
+
+let field_atom name xs =
+  match field name xs with
+  | Atom a -> a
+  | List _ -> Fmt.failwith "Expected %S to be an atom!" name
+
+let field_bool name xs =
+  bool_of_string (field_atom name xs)
+
+let index_lib acc fields =
+  let name = field_atom "name" fields in
+  let local = if field_bool "local" fields then `Internal else `External in
+  Library_map.add name local acc
+
+let index_item acc = function
+  | List [Atom "library"; List fields] -> index_lib acc fields
+  | _ -> acc
+
+let make_index = function
+  | List libs -> List.fold_left index_item Library_map.empty libs
+  | Atom _ -> failwith "Bad 'dune describe' output!"
+
+let describe () =
+  Bos.OS.Cmd.run_out (Bos.Cmd.(v "dune" % "describe" % "--format=csexp" % "--lang=0.1"))
+  |> Bos.OS.Cmd.to_string
+  |> or_die
+  |> Sexp.parse_string
+  |> function
+  | Error (_, e) -> Fmt.failwith "Error parsing 'dune describe' output: %s" e
+  | Ok x -> make_index x
+
+let lookup = Library_map.find_opt

--- a/dune_project.mli
+++ b/dune_project.mli
@@ -1,0 +1,25 @@
+open Types
+
+type t
+
+val parse : unit -> t
+(** [parse ()] loads the "dune-project" file. *)
+
+val generate_opam_enabled : t -> bool
+(** Check whether (generate_opam_files true) is present. *)
+
+val update : (_ * Change.t list) Paths.t -> t -> t
+
+val write_project_file : t -> unit
+
+type index
+
+val describe : unit -> index
+(** Create an index of the project's libraries, using "dune describe". *)
+
+val lookup : string -> index -> [`Internal | `External] option
+(** [lookup lib index] returns information from "dune describe" about [lib]. *)
+
+module Deps : sig
+  val get_external_lib_deps : pkg:string -> target:string -> Libraries.t
+end

--- a/main.ml
+++ b/main.ml
@@ -15,6 +15,7 @@ let dune_build_install =
 let get_libraries ~pkg ~target =
   Dune_project.Deps.get_external_lib_deps ~pkg ~target
   |> Libraries.remove "threads"         (* META file is provided by ocamlfind, but dune doesn't need it *)
+  |> Libraries.remove "str"
   |> Libraries.add "dune"               (* We always need dune *)
 
 let to_opam lib =

--- a/main.ml
+++ b/main.ml
@@ -1,7 +1,5 @@
 open Types
 
-module Libraries = Set.Make(String)
-
 let or_die = function
   | Ok x -> x
   | Error (`Msg m) -> failwith m
@@ -11,30 +9,11 @@ let () =
 
 let index = Index.create ()
 
-(* todo: we should probably select machine readable output.
-   But passing --sexp just tells you to use unstable mode anyway.
-   We use [tmp_dir] so that "--only-packages" doesn't invalidate the existing build. *)
-let dune_external_lib_deps ~tmp_dir ~pkg ~target =
-  let tmp_dir = Fpath.to_string tmp_dir in
-  Bos.Cmd.(v "dune" % "external-lib-deps" % "--only-packages" % pkg % "--build-dir" % tmp_dir % target)
-
 let dune_build_install =
   Bos.Cmd.(v "dune" % "build" %% (on (Unix.(isatty stderr)) (v "--display=progress")) % "@install")
 
-(* Get the ocamlfind dependencies of [pkg]. *)
 let get_libraries ~pkg ~target =
-  Bos.OS.Dir.with_tmp "dune-opam-lint-%s" (fun tmp_dir () ->
-      Bos.OS.Cmd.run_out (dune_external_lib_deps ~tmp_dir ~pkg ~target)
-      |> Bos.OS.Cmd.to_lines
-      |> or_die
-    ) ()
-  |> or_die
-  |> List.filter_map (fun line ->
-      match Astring.String.cut ~sep:" " line with
-      | Some ("-", lib) -> Some lib
-      | _ -> None
-    )
-  |> Libraries.of_list
+  Dune_project.Deps.get_external_lib_deps ~pkg ~target
   |> Libraries.remove "threads"         (* META file is provided by ocamlfind, but dune doesn't need it *)
   |> Libraries.add "dune"               (* We always need dune *)
 
@@ -46,7 +25,8 @@ let to_opam lib =
     Fmt.pr "WARNING: can't find opam package providing %S!@." lib;
     OpamPackage.create (OpamPackage.Name.of_string lib) (OpamPackage.Version.of_string "0")
 
-let to_opam_set libs =
+let to_opam_set ~project libs =
+  let libs = libs |> Libraries.filter (fun lib -> Dune_project.lookup lib project <> Some `Internal) in
   Libraries.fold (fun lib acc -> OpamPackage.Set.add (to_opam lib) acc) libs OpamPackage.Set.empty
 
 let get_opam_files () =
@@ -77,9 +57,9 @@ let display path (_opam, problems) =
     Fmt.(styled `Bold string) pkg
     pp_problems problems
 
-let generate_report ~opam pkg =
-  let build = get_libraries ~pkg ~target:"@install" |> to_opam_set in
-  let test = get_libraries ~pkg ~target:"@runtest" |> to_opam_set in
+let generate_report ~project ~opam pkg =
+  let build = get_libraries ~pkg ~target:"@install" |> to_opam_set ~project in
+  let test = get_libraries ~pkg ~target:"@runtest" |> to_opam_set ~project in
   let opam_deps = OpamFile.OPAM.depends opam |> Formula.classify in
   let build_problems =
     OpamPackage.Set.to_seq build
@@ -137,8 +117,9 @@ let main force dir =
   if Paths.is_empty opam_files then failwith "No *.opam files found!";
   let stale_files = Paths.merge check_identical old_opam_files opam_files in
   stale_files |> Paths.iter (fun path msg -> Fmt.pr "%s: %s after 'dune build @install'!@." path msg);
+  let project = Dune_project.describe () in
   opam_files |> Paths.mapi (fun path opam ->
-      (opam, generate_report ~opam (Filename.chop_suffix path ".opam"))
+      (opam, generate_report ~project ~opam (Filename.chop_suffix path ".opam"))
     )
   |> fun report ->
   Paths.iter display report;

--- a/tests/test_vendoring.t
+++ b/tests/test_vendoring.t
@@ -1,0 +1,63 @@
+Create a project with vendored libraries.
+`bin` depends on `lib` (an internal library).
+`lib` depends on `vendored`.
+We want to record the dependencies of `bin` and `lib` in the opam file, but not the dependencies of `vendored`,
+since they should be listed in the vendored opam files instead.
+
+  $ mkdir bin lib vendored
+
+  $ cat > dune-project << EOF
+  > (lang dune 2.7)
+  > (generate_opam_files true)
+  > (package
+  >  (name main)
+  >  (synopsis "Main package")
+  >  (depends libfoo))
+  > EOF
+
+  $ cat > dune << EOF
+  > (vendored_dirs vendored)
+  > EOF
+
+  $ cat > bin/dune << EOF
+  > (executable
+  >  (name main)
+  >  (public_name main)
+  >  (libraries lib))
+  > EOF
+
+  $ cat > lib/dune << EOF
+  > (library
+  >  (name lib)
+  >  (libraries findlib vendored))
+  > EOF
+
+  $ cat > vendored/dune << EOF
+  > (library
+  >  (name vendored)
+  >  (public_name vendored)
+  >  (libraries bos))
+  > EOF
+
+  $ cat > vendored/dune-project << EOF
+  > (lang dune 2.7)
+  > EOF
+
+  $ touch bin/main.ml lib/lib.ml
+  $ (cd vendored && touch vendored.ml vendored.opam)
+  $ dune build
+
+Check configuration:
+
+  $ dune external-lib-deps -p main @install
+  These are the external library dependencies in the default context:
+  - bos
+  - findlib
+
+Check that the missing findlib for "lib" is detected, but not "vendored"'s dependency
+on "bos":
+
+  $ dune-opam-lint </dev/null 2>&1 | sed 's/= [^)}]*/= */g'
+  main.opam: changes needed:
+    "ocamlfind" {>= *}
+  Run with -f to apply changes in non-interactive mode.

--- a/types.ml
+++ b/types.ml
@@ -1,5 +1,7 @@
 module Paths = Map.Make(String)
 
+module Libraries = Set.Make(String)
+
 module Change = struct
   type t =
     [ `Remove_with_test of OpamPackage.Name.t


### PR DESCRIPTION
If we depend on a vendored library, don't include its dependencies too. Sometimes you do want this, but often vendoring is just being used as a form of pinning. Ideally dune would indicate which, but for now assume the pinning case.