### PR TITLE
Rename to opam-dune-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# dune-opam-lint
+# opam-dune-lint
 
-`dune-opam-lint` checks that all ocamlfind libraries listed as dune
+`opam-dune-lint` checks that all ocamlfind libraries listed as dune
 dependencies have corresponding opam dependencies listed in the opam files.
 If not, it offers to add them (either to your opam files, or to your `dune-project` if you're generating your opam files from that).
 
@@ -11,7 +11,7 @@ $ ls *.opam
 ocaml-ci-api.opam     ocaml-ci-service.opam  ocaml-ci-web.opam
 ocaml-ci-client.opam  ocaml-ci-solver.opam
 
-$ dune-opam-lint
+$ opam-dune-lint
 ocaml-ci-api.opam: OK
 ocaml-ci-client.opam: OK
 ocaml-ci-service.opam: changes needed:
@@ -35,7 +35,7 @@ It works as follows:
 6. Checks that each required opam package is listed in the opam file.
 7. For any missing packages, it offers to add a suitable dependency, using the installed package's version as the default lower-bound.
 
-`dune-opam-lint` can be run manually to update your project, or as part of CI to check for missing dependencies.
+`opam-dune-lint` can be run manually to update your project, or as part of CI to check for missing dependencies.
 It exits with a non-zero status if changes are needed, or if the opam files were not up-to-date with the `dune-project` file.
 When run interactively, it asks for confirmation before writing files.
 If `stdin` is not a tty, then it does not write changes unless run with `-f`.

--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
 (executable
- (public_name dune-opam-lint)
+ (public_name opam-dune-lint)
  (name main)
  (libraries astring fmt fmt.tty bos opam-format opam-state findlib dune-private-libs.dune-lang cmdliner sexplib))

--- a/dune-project
+++ b/dune-project
@@ -1,13 +1,13 @@
 (lang dune 2.7)
-(name dune-opam-lint)
+(name opam-dune-lint)
 (formatting disabled)
 (generate_opam_files true)
-(source (github talex5/dune-opam-lint))
+(source (github ocurrent/opam-dune-lint))
 (authors "talex5@gmail.com")
 (maintainers "talex5@gmail.com")
 (cram enable)
 (package
- (name dune-opam-lint)
+ (name opam-dune-lint)
  (synopsis "Ensure dune and opam dependencies are consistent")
  (depends
   (astring (>= 0.8.5))

--- a/dune_project.ml
+++ b/dune_project.ml
@@ -154,7 +154,7 @@ module Deps = struct
 
   (* Get the ocamlfind dependencies of [pkg]. *)
   let get_external_lib_deps ~pkg ~target =
-    Bos.OS.Dir.with_tmp "dune-opam-lint-%s" (fun tmp_dir () ->
+    Bos.OS.Dir.with_tmp "opam-dune-lint-%s" (fun tmp_dir () ->
         Bos.OS.Cmd.run_out (dune_external_lib_deps ~tmp_dir ~pkg ~target)
         |> Bos.OS.Cmd.to_string
         |> or_die

--- a/main.ml
+++ b/main.ml
@@ -161,7 +161,7 @@ let force =
 let cmd =
   let doc = "keep dune and opam files in sync" in
   Term.(const main $ force $ dir),
-  Term.info "dune-opam-lint" ~doc
+  Term.info "opam-dune-lint" ~doc
 
 let () =
   Fmt_tty.setup_std_outputs ();

--- a/opam-dune-lint.opam
+++ b/opam-dune-lint.opam
@@ -3,8 +3,8 @@ opam-version: "2.0"
 synopsis: "Ensure dune and opam dependencies are consistent"
 maintainer: ["talex5@gmail.com"]
 authors: ["talex5@gmail.com"]
-homepage: "https://github.com/talex5/dune-opam-lint"
-bug-reports: "https://github.com/talex5/dune-opam-lint/issues"
+homepage: "https://github.com/ocurrent/opam-dune-lint"
+bug-reports: "https://github.com/ocurrent/opam-dune-lint/issues"
 depends: [
   "dune" {>= "2.7"}
   "astring" {>= "0.8.5"}
@@ -33,4 +33,4 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/talex5/dune-opam-lint.git"
+dev-repo: "git+https://github.com/ocurrent/opam-dune-lint.git"

--- a/tests/dune
+++ b/tests/dune
@@ -1,1 +1,1 @@
-(cram (deps %{bin:dune-opam-lint}))
+(cram (deps %{bin:opam-dune-lint}))

--- a/tests/test_dune.t
+++ b/tests/test_dune.t
@@ -28,7 +28,7 @@ Create a simple dune project:
 
 Check that the missing libraries are detected:
 
-  $ dune-opam-lint </dev/null 2>&1 | sed 's/= [^)}]*/= */g'
+  $ opam-dune-lint </dev/null 2>&1 | sed 's/= [^)}]*/= */g'
   test.opam: changes needed:
     "fmt" {>= *}
     "bos" {with-test & >= *}
@@ -37,7 +37,7 @@ Check that the missing libraries are detected:
 
 Check that the missing libraries get added:
 
-  $ dune-opam-lint -f 2>&1 | sed 's/= [^)}]*/= */g'
+  $ opam-dune-lint -f 2>&1 | sed 's/= [^)}]*/= */g'
   test.opam: changes needed:
     "fmt" {>= *}
     "bos" {with-test & >= *}
@@ -75,7 +75,7 @@ Check adding and removing of test markers:
 
   $ dune build @install
 
-  $ dune-opam-lint -f 2>&1 | sed 's/= [^)}]*/= */g'
+  $ opam-dune-lint -f 2>&1 | sed 's/= [^)}]*/= */g'
   test.opam: changes needed:
     "fmt" (remove {with-test})
     "ocamlfind" (remove {with-test})
@@ -96,5 +96,5 @@ Check adding and removing of test markers:
     (ocamlfind (>= *))
     libfoo))
 
-  $ dune-opam-lint
+  $ opam-dune-lint
   test.opam: OK

--- a/tests/test_vendoring.t
+++ b/tests/test_vendoring.t
@@ -57,7 +57,7 @@ Check configuration:
 Check that the missing findlib for "lib" is detected, but not "vendored"'s dependency
 on "bos":
 
-  $ dune-opam-lint </dev/null 2>&1 | sed 's/= [^)}]*/= */g'
+  $ opam-dune-lint </dev/null 2>&1 | sed 's/= [^)}]*/= */g'
   main.opam: changes needed:
     "ocamlfind" {>= *}
   Run with -f to apply changes in non-interactive mode.


### PR DESCRIPTION
This is mainly so that it can be used as an opam plugin.