### PR TITLE
Improve the displayed reports

### DIFF
--- a/dune_project.mli
+++ b/dune_project.mli
@@ -21,5 +21,8 @@ val lookup : string -> index -> [`Internal | `External] option
 (** [lookup lib index] returns information from "dune describe" about [lib]. *)
 
 module Deps : sig
-  val get_external_lib_deps : pkg:string -> target:string -> Libraries.t
+  type t = Dir_set.t Libraries.t
+  (** The set of OCamlfind libraries needed, each with the directories needing it. *)
+
+  val get_external_lib_deps : pkg:string -> target:string -> t
 end

--- a/main.ml
+++ b/main.ml
@@ -127,6 +127,8 @@ let main force dir =
     )
   |> fun report ->
   Paths.iter display report;
+  if Paths.exists (fun _ (_, changes) -> List.exists Change.includes_version changes) report then
+    Fmt.pr "Note: version numbers are just suggestions based on the currently installed version.@.";
   let have_changes = Paths.exists (fun _ -> function (_, []) -> false | _ -> true) report in
   if have_changes then (
     if force || confirm_with_user () then (

--- a/main.ml
+++ b/main.ml
@@ -139,9 +139,10 @@ let main force dir =
       ) else (
         Paths.iter update_opam_file report
       )
+    ) else (
+      exit 1
     )
   );
-  if have_changes then exit 1;
   if not (Paths.is_empty stale_files) then exit 1
 
 open Cmdliner

--- a/main.ml
+++ b/main.ml
@@ -12,7 +12,7 @@ let dune_build_install =
 
 let get_libraries ~pkg ~target =
   Dune_project.Deps.get_external_lib_deps ~pkg ~target
-  |> Libraries.add "dune"               (* We always need dune *)
+  |> Libraries.add "dune" Dir_set.empty              (* We always need dune *)
 
 let to_opam ~index lib =
   match Astring.String.take ~sat:((<>) '.') lib with
@@ -24,13 +24,14 @@ let to_opam ~index lib =
       Fmt.pr "WARNING: can't find opam package providing %S!@." lib;
       Some (OpamPackage.create (OpamPackage.Name.of_string lib) (OpamPackage.Version.of_string "0"))
 
+(* Convert a map of (ocamlfind-library -> hints) to a map of (opam-package -> hints). *)
 let to_opam_set ~project ~index libs =
-  let libs = libs |> Libraries.filter (fun lib -> Dune_project.lookup lib project <> Some `Internal) in
-  Libraries.fold (fun lib acc ->
+  let libs = libs |> Libraries.filter (fun lib _ -> Dune_project.lookup lib project <> Some `Internal) in
+  Libraries.fold (fun lib dirs acc ->
       match to_opam ~index lib with
-      | Some pkg -> OpamPackage.Set.add pkg acc
+      | Some pkg -> OpamPackage.Map.update pkg (Dir_set.union dirs) Dir_set.empty acc
       | None -> acc
-    ) libs OpamPackage.Set.empty
+    ) libs OpamPackage.Map.empty
 
 let get_opam_files () =
   Sys.readdir "."
@@ -52,7 +53,7 @@ let check_identical _path a b =
 
 let pp_problems f = function
   | [] -> Fmt.pf f " %a" Fmt.(styled `Green string) "OK"
-  | problems -> Fmt.pf f " changes needed:@,%a" Fmt.(list ~sep:cut Change.pp) problems
+  | problems -> Fmt.pf f " changes needed:@,%a" Fmt.(list ~sep:cut Change_with_hint.pp) problems
 
 let display path (_opam, problems) =
   let pkg = Filename.chop_suffix path ".opam" in
@@ -65,26 +66,29 @@ let generate_report ~project ~index ~opam pkg =
   let test = get_libraries ~pkg ~target:"@runtest" |> to_opam_set ~project ~index in
   let opam_deps = OpamFile.OPAM.depends opam |> Formula.classify in
   let build_problems =
-    OpamPackage.Set.to_seq build
+    OpamPackage.Map.to_seq build
     |> List.of_seq
-    |> List.concat_map (fun dep ->
+    |> List.concat_map (fun (dep, hint) ->
         let dep_name = OpamPackage.name dep in
         match OpamPackage.Name.Map.find_opt dep_name opam_deps with
         | Some `Build -> []
-        | Some `Test -> [`Remove_with_test dep_name]
-        | None -> [`Add_build_dep dep]
+        | Some `Test -> [`Remove_with_test dep_name, hint]
+        | None -> [`Add_build_dep dep, hint]
       )
   in
   let test_problems =
-    OpamPackage.Set.diff test build
-    |> OpamPackage.Set.to_seq
+    test
+    |> OpamPackage.Map.to_seq
     |> List.of_seq
-    |> List.concat_map (fun dep ->
-        let dep_name = OpamPackage.name dep in
-        match OpamPackage.Name.Map.find_opt dep_name opam_deps with
-        | Some `Test -> []
-        | Some `Build -> [`Add_with_test dep_name]
-        | None -> [`Add_test_dep dep]
+    |> List.concat_map (fun (dep, hint) ->
+        if OpamPackage.Map.mem dep build then []
+        else (
+          let dep_name = OpamPackage.name dep in
+          match OpamPackage.Name.Map.find_opt dep_name opam_deps with
+          | Some `Test -> []
+          | Some `Build -> [`Add_with_test dep_name, hint]
+          | None -> [`Add_test_dep dep, hint]
+        )
       )
   in
   build_problems @ test_problems
@@ -127,8 +131,9 @@ let main force dir =
     )
   |> fun report ->
   Paths.iter display report;
-  if Paths.exists (fun _ (_, changes) -> List.exists Change.includes_version changes) report then
+  if Paths.exists (fun _ (_, changes) -> List.exists Change_with_hint.includes_version changes) report then
     Fmt.pr "Note: version numbers are just suggestions based on the currently installed version.@.";
+  let report = Paths.map (fun (opam, changes) -> opam, List.map Change_with_hint.remove_hint changes) report in
   let have_changes = Paths.exists (fun _ -> function (_, []) -> false | _ -> true) report in
   if have_changes then (
     if force || confirm_with_user () then (

--- a/tests/test_dune.t
+++ b/tests/test_dune.t
@@ -34,9 +34,9 @@ Check that the missing libraries are detected:
 
   $ opam-dune-lint </dev/null
   test.opam: changes needed:
-    "fmt" {>= 1.0}
-    "bos" {with-test & >= 1.0}
-    "opam-state" {with-test & >= 1.0}
+    "fmt" {>= 1.0}                           [from /]
+    "bos" {with-test & >= 1.0}               [from /]
+    "opam-state" {with-test & >= 1.0}        [from /]
   Note: version numbers are just suggestions based on the currently installed version.
   Run with -f to apply changes in non-interactive mode.
   [1]
@@ -45,9 +45,9 @@ Check that the missing libraries get added:
 
   $ opam-dune-lint -f
   test.opam: changes needed:
-    "fmt" {>= 1.0}
-    "bos" {with-test & >= 1.0}
-    "opam-state" {with-test & >= 1.0}
+    "fmt" {>= 1.0}                           [from /]
+    "bos" {with-test & >= 1.0}               [from /]
+    "opam-state" {with-test & >= 1.0}        [from /]
   Note: version numbers are just suggestions based on the currently installed version.
   Wrote "dune-project"
 
@@ -84,10 +84,10 @@ Check adding and removing of test markers:
 
   $ opam-dune-lint -f
   test.opam: changes needed:
-    "fmt"                          (remove {with-test})
-    "ocamlfind"                    (remove {with-test})
-    "bos" {with-test}              (missing {with-test} annotation)
-    "opam-state" {with-test}       (missing {with-test} annotation)
+    "fmt"                                    [from /] (remove {with-test})
+    "ocamlfind"                              [from /] (remove {with-test})
+    "bos" {with-test}                        [from /] (missing {with-test} annotation)
+    "opam-state" {with-test}                 [from /] (missing {with-test} annotation)
   Wrote "dune-project"
 
   $ cat dune-project | sed 's/= [^)}]*/= */g'

--- a/tests/test_dune.t
+++ b/tests/test_dune.t
@@ -77,10 +77,10 @@ Check adding and removing of test markers:
 
   $ opam-dune-lint -f 2>&1 | sed 's/= [^)}]*/= */g'
   test.opam: changes needed:
-    "fmt" (remove {with-test})
-    "ocamlfind" (remove {with-test})
-    "bos" {with-test} (missing {with-test} annotation)
-    "opam-state" {with-test} (missing {with-test} annotation)
+    "fmt"                          (remove {with-test})
+    "ocamlfind"                    (remove {with-test})
+    "bos" {with-test}              (missing {with-test} annotation)
+    "opam-state" {with-test}       (missing {with-test} annotation)
   Wrote "dune-project"
 
   $ cat dune-project | sed 's/= [^)}]*/= */g'

--- a/tests/test_dune.t
+++ b/tests/test_dune.t
@@ -26,22 +26,27 @@ Create a simple dune project:
   $ touch main.ml test.ml
   $ dune build
 
+Replace all version numbers with "1.0" to get predictable outut.
+
+  $ export OPAM_DUNE_LINT_TESTS=y
+
 Check that the missing libraries are detected:
 
-  $ opam-dune-lint </dev/null 2>&1 | sed 's/= [^)}]*/= */g'
+  $ opam-dune-lint </dev/null
   test.opam: changes needed:
-    "fmt" {>= *}
-    "bos" {with-test & >= *}
-    "opam-state" {with-test & >= *}
+    "fmt" {>= 1.0}
+    "bos" {with-test & >= 1.0}
+    "opam-state" {with-test & >= 1.0}
   Run with -f to apply changes in non-interactive mode.
+  [1]
 
 Check that the missing libraries get added:
 
-  $ opam-dune-lint -f 2>&1 | sed 's/= [^)}]*/= */g'
+  $ opam-dune-lint -f
   test.opam: changes needed:
-    "fmt" {>= *}
-    "bos" {with-test & >= *}
-    "opam-state" {with-test & >= *}
+    "fmt" {>= 1.0}
+    "bos" {with-test & >= 1.0}
+    "opam-state" {with-test & >= 1.0}
   Wrote "dune-project"
 
   $ cat dune-project | sed 's/= [^)}]*/= */g'
@@ -75,7 +80,7 @@ Check adding and removing of test markers:
 
   $ dune build @install
 
-  $ opam-dune-lint -f 2>&1 | sed 's/= [^)}]*/= */g'
+  $ opam-dune-lint -f
   test.opam: changes needed:
     "fmt"                          (remove {with-test})
     "ocamlfind"                    (remove {with-test})

--- a/tests/test_dune.t
+++ b/tests/test_dune.t
@@ -37,6 +37,7 @@ Check that the missing libraries are detected:
     "fmt" {>= 1.0}
     "bos" {with-test & >= 1.0}
     "opam-state" {with-test & >= 1.0}
+  Note: version numbers are just suggestions based on the currently installed version.
   Run with -f to apply changes in non-interactive mode.
   [1]
 
@@ -47,6 +48,7 @@ Check that the missing libraries get added:
     "fmt" {>= 1.0}
     "bos" {with-test & >= 1.0}
     "opam-state" {with-test & >= 1.0}
+  Note: version numbers are just suggestions based on the currently installed version.
   Wrote "dune-project"
 
   $ cat dune-project | sed 's/= [^)}]*/= */g'

--- a/tests/test_vendoring.t
+++ b/tests/test_vendoring.t
@@ -47,6 +47,10 @@ since they should be listed in the vendored opam files instead.
   $ (cd vendored && touch vendored.ml vendored.opam)
   $ dune build
 
+Replace all version numbers with "1.0" to get predictable outut.
+
+  $ export OPAM_DUNE_LINT_TESTS=y
+
 Check configuration:
 
   $ dune external-lib-deps -p main @install
@@ -57,7 +61,8 @@ Check configuration:
 Check that the missing findlib for "lib" is detected, but not "vendored"'s dependency
 on "bos":
 
-  $ opam-dune-lint </dev/null 2>&1 | sed 's/= [^)}]*/= */g'
+  $ opam-dune-lint </dev/null
   main.opam: changes needed:
-    "ocamlfind" {>= *}
+    "ocamlfind" {>= 1.0}
   Run with -f to apply changes in non-interactive mode.
+  [1]

--- a/tests/test_vendoring.t
+++ b/tests/test_vendoring.t
@@ -64,5 +64,6 @@ on "bos":
   $ opam-dune-lint </dev/null
   main.opam: changes needed:
     "ocamlfind" {>= 1.0}
+  Note: version numbers are just suggestions based on the currently installed version.
   Run with -f to apply changes in non-interactive mode.
   [1]

--- a/tests/test_vendoring.t
+++ b/tests/test_vendoring.t
@@ -63,7 +63,7 @@ on "bos":
 
   $ opam-dune-lint </dev/null
   main.opam: changes needed:
-    "ocamlfind" {>= 1.0}
+    "ocamlfind" {>= 1.0}                     [from lib]
   Note: version numbers are just suggestions based on the currently installed version.
   Run with -f to apply changes in non-interactive mode.
   [1]

--- a/types.ml
+++ b/types.ml
@@ -15,6 +15,12 @@ module Change = struct
     if Sys.getenv_opt "OPAM_DUNE_LINT_TESTS" = Some "y" then Fun.const "1.0"
     else OpamPackage.version_to_string
 
+  let includes_version = function
+    | `Remove_with_test _
+    | `Add_with_test _ -> false
+    | `Add_build_dep _
+    | `Add_test_dep _ -> true
+
   let pp f t =
     let change, hint =
       match t with

--- a/types.ml
+++ b/types.ml
@@ -1,6 +1,8 @@
+module Dir_set = Set.Make(String)
+
 module Paths = Map.Make(String)
 
-module Libraries = Set.Make(String)
+module Libraries = Map.Make(String)
 
 module Change = struct
   type t =
@@ -8,6 +10,10 @@ module Change = struct
     | `Add_with_test of OpamPackage.Name.t
     | `Add_build_dep of OpamPackage.t
     | `Add_test_dep of OpamPackage.t ]
+end
+
+module Change_with_hint = struct
+  type t = Change.t * Dir_set.t
 
   let pp_name = Fmt.using OpamPackage.Name.to_string Fmt.(quote string)
 
@@ -15,22 +21,30 @@ module Change = struct
     if Sys.getenv_opt "OPAM_DUNE_LINT_TESTS" = Some "y" then Fun.const "1.0"
     else OpamPackage.version_to_string
 
-  let includes_version = function
+  let includes_version (c, _) =
+    match c with
     | `Remove_with_test _
     | `Add_with_test _ -> false
     | `Add_build_dep _
     | `Add_test_dep _ -> true
 
-  let pp f t =
+  let pp f (c, dirs) =
+    let dirs = Dir_set.map (function "." -> "/" | x -> x) dirs in
     let change, hint =
-      match t with
-      | `Remove_with_test name -> Fmt.str "%a" pp_name name, "(remove {with-test})"
-      | `Add_with_test name -> Fmt.str "%a {with-test}" pp_name name, "(missing {with-test} annotation)"
-      | `Add_build_dep dep -> Fmt.str "%a {>= %s}" pp_name (OpamPackage.name dep) (version_to_string dep), ""
-      | `Add_test_dep dep -> Fmt.str "%a {with-test & >= %s}" pp_name (OpamPackage.name dep) (version_to_string dep), ""
+      match c with
+      | `Remove_with_test name -> Fmt.str "%a" pp_name name, ["(remove {with-test})"]
+      | `Add_with_test name -> Fmt.str "%a {with-test}" pp_name name, ["(missing {with-test} annotation)"]
+      | `Add_build_dep dep -> Fmt.str "%a {>= %s}" pp_name (OpamPackage.name dep) (version_to_string dep), []
+      | `Add_test_dep dep -> Fmt.str "%a {with-test & >= %s}" pp_name (OpamPackage.name dep) (version_to_string dep), []
     in
-    if hint = "" then
+    let hint =
+      if Dir_set.is_empty dirs then hint
+      else Fmt.strf "[from @[<h>%a@]]" Fmt.(list ~sep:comma string) (Dir_set.elements dirs) :: hint
+    in
+    if hint = [] then
       Fmt.string f change
     else
-      Fmt.pf f "%-30s %s" change hint
+      Fmt.pf f "@[<h>%-40s %a@]" change Fmt.(list ~sep:sp string) hint
+
+  let remove_hint (t:t) = fst t
 end

--- a/types.ml
+++ b/types.ml
@@ -11,13 +11,17 @@ module Change = struct
 
   let pp_name = Fmt.using OpamPackage.Name.to_string Fmt.(quote string)
 
+  let version_to_string =
+    if Sys.getenv_opt "OPAM_DUNE_LINT_TESTS" = Some "y" then Fun.const "1.0"
+    else OpamPackage.version_to_string
+
   let pp f t =
     let change, hint =
       match t with
       | `Remove_with_test name -> Fmt.str "%a" pp_name name, "(remove {with-test})"
       | `Add_with_test name -> Fmt.str "%a {with-test}" pp_name name, "(missing {with-test} annotation)"
-      | `Add_build_dep dep -> Fmt.str "%a {>= %s}" pp_name (OpamPackage.name dep) (OpamPackage.version_to_string dep), ""
-      | `Add_test_dep dep -> Fmt.str "%a {with-test & >= %s}" pp_name (OpamPackage.name dep) (OpamPackage.version_to_string dep), ""
+      | `Add_build_dep dep -> Fmt.str "%a {>= %s}" pp_name (OpamPackage.name dep) (version_to_string dep), ""
+      | `Add_test_dep dep -> Fmt.str "%a {with-test & >= %s}" pp_name (OpamPackage.name dep) (version_to_string dep), ""
     in
     if hint = "" then
       Fmt.string f change

--- a/types.ml
+++ b/types.ml
@@ -11,9 +11,16 @@ module Change = struct
 
   let pp_name = Fmt.using OpamPackage.Name.to_string Fmt.(quote string)
 
-  let pp f = function
-    | `Remove_with_test name -> Fmt.pf f "%a (remove {with-test})" pp_name name
-    | `Add_with_test name -> Fmt.pf f "%a {with-test} (missing {with-test} annotation)" pp_name name
-    | `Add_build_dep dep -> Fmt.pf f "%a {>= %s}" pp_name (OpamPackage.name dep) (OpamPackage.version_to_string dep)
-    | `Add_test_dep dep -> Fmt.pf f "%a {with-test & >= %s}" pp_name (OpamPackage.name dep) (OpamPackage.version_to_string dep)
+  let pp f t =
+    let change, hint =
+      match t with
+      | `Remove_with_test name -> Fmt.str "%a" pp_name name, "(remove {with-test})"
+      | `Add_with_test name -> Fmt.str "%a {with-test}" pp_name name, "(missing {with-test} annotation)"
+      | `Add_build_dep dep -> Fmt.str "%a {>= %s}" pp_name (OpamPackage.name dep) (OpamPackage.version_to_string dep), ""
+      | `Add_test_dep dep -> Fmt.str "%a {with-test & >= %s}" pp_name (OpamPackage.name dep) (OpamPackage.version_to_string dep), ""
+    in
+    if hint = "" then
+      Fmt.string f change
+    else
+      Fmt.pf f "%-30s %s" change hint
 end


### PR DESCRIPTION
- Move hints to their own column
- Inform users about where the version numbers come from
- Don't return an error status if the files were wrong but got updated
- Show which directories contributed to each dependency

Before:

    current_ocluster.opam: changes needed:
      "ppx_deriving" {>= 5.1}
    ocluster-api.opam: changes needed:
      "ppx_deriving" {>= 5.1}
    ocluster.opam: changes needed:
      "capnp-rpc-lwt" {>= 0.8.0}
      "capnp-rpc-net" {>= 0.8.0}
      "ppx_sexp_conv" {>= v0.14.1}
      "prometheus" {>= 0.7}
      "alcotest-lwt" {with-test} (missing {with-test} annotation)

After:

    current_ocluster.opam: changes needed:
      "ppx_deriving" {>= 5.1}                  [from (ppx), ocurrent-plugin]
    ocluster-api.opam: changes needed:
      "ppx_deriving" {>= 5.1}                  [from (ppx), api]
    ocluster.opam: changes needed:
      "capnp-rpc-lwt" {>= 0.8.0}               [from scheduler, worker]
      "capnp-rpc-net" {>= 0.8.0}               [from scheduler]
      "ppx_sexp_conv" {>= v0.14.1}             [from (ppx)]
      "prometheus" {>= 0.7}                    [from scheduler]
      "alcotest-lwt" {with-test}               [from test] (missing {with-test} annotation)
    Note: version numbers are just suggestions based on the currently installed version.