### PR TITLE
Require opam libraries compatible with the client

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -10,14 +10,4 @@
  (name opam-dune-lint)
  (synopsis "Ensure dune and opam dependencies are consistent")
  (description
-  "opam-dune-lint checks that all ocamlfind libraries listed as dune dependencies have corresponding opam dependencies listed in the opam files. If not, it offers to add them (either to your opam files, or to your dune-project if you're generating your opam files from that).")
- (depends
-  (astring (>= 0.8.5))
-  (sexplib (>= v0.14.0))
-  (cmdliner (>= 1.0.4))
-  (dune-private-libs (>= 2.8.0))
-  (ocaml (>= 4.11.0))
-  bos
-  fmt
-  opam-state
-  opam-format))
+  "opam-dune-lint checks that all ocamlfind libraries listed as dune dependencies have corresponding opam dependencies listed in the opam files. If not, it offers to add them (either to your opam files, or to your dune-project if you're generating your opam files from that)."))

--- a/dune-project
+++ b/dune-project
@@ -10,4 +10,14 @@
  (name opam-dune-lint)
  (synopsis "Ensure dune and opam dependencies are consistent")
  (description
-  "opam-dune-lint checks that all ocamlfind libraries listed as dune dependencies have corresponding opam dependencies listed in the opam files. If not, it offers to add them (either to your opam files, or to your dune-project if you're generating your opam files from that)."))
+  "opam-dune-lint checks that all ocamlfind libraries listed as dune dependencies have corresponding opam dependencies listed in the opam files. If not, it offers to add them (either to your opam files, or to your dune-project if you're generating your opam files from that).")
+ (depends
+  (astring (>= 0.8.5))
+  (sexplib (>= v0.14.0))
+  (cmdliner (>= 1.0.4))
+  (dune-private-libs (>= 2.8.0))
+  (ocaml (>= 4.11.0))
+  bos
+  fmt
+  (opam-state (>= 2.1.0~~))
+  opam-format))

--- a/opam-dune-lint.opam
+++ b/opam-dune-lint.opam
@@ -7,19 +7,6 @@ maintainer: ["talex5@gmail.com"]
 authors: ["talex5@gmail.com"]
 homepage: "https://github.com/ocurrent/opam-dune-lint"
 bug-reports: "https://github.com/ocurrent/opam-dune-lint/issues"
-depends: [
-  "dune" {>= "2.7"}
-  "astring" {>= "0.8.5"}
-  "sexplib" {>= "v0.14.0"}
-  "cmdliner" {>= "1.0.4"}
-  "dune-private-libs" {>= "2.8.0"}
-  "ocaml" {>= "4.11.0"}
-  "bos"
-  "fmt"
-  "opam-state" {>= opam-version}
-  "opam-format"
-  "odoc" {with-doc}
-]
 build: [
   ["dune" "subst"] {dev}
   [
@@ -36,3 +23,16 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocurrent/opam-dune-lint.git"
 flags: plugin
+depends: [
+  "dune" {>= "2.7"}
+  "astring" {>= "0.8.5"}
+  "sexplib" {>= "v0.14.0"}
+  "cmdliner" {>= "1.0.4"}
+  "dune-private-libs" {>= "2.8.0"}
+  "ocaml" {>= "4.11.0"}
+  "bos"
+  "fmt"
+  "opam-state" {>= opam-version}
+  "opam-format"
+  "odoc" {with-doc}
+]

--- a/opam-dune-lint.opam
+++ b/opam-dune-lint.opam
@@ -7,6 +7,19 @@ maintainer: ["talex5@gmail.com"]
 authors: ["talex5@gmail.com"]
 homepage: "https://github.com/ocurrent/opam-dune-lint"
 bug-reports: "https://github.com/ocurrent/opam-dune-lint/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "astring" {>= "0.8.5"}
+  "sexplib" {>= "v0.14.0"}
+  "cmdliner" {>= "1.0.4"}
+  "dune-private-libs" {>= "2.8.0"}
+  "ocaml" {>= "4.11.0"}
+  "bos"
+  "fmt"
+  "opam-state" {>= "2.1.0~~"}
+  "opam-format"
+  "odoc" {with-doc}
+]
 build: [
   ["dune" "subst"] {dev}
   [
@@ -23,16 +36,3 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocurrent/opam-dune-lint.git"
 flags: plugin
-depends: [
-  "dune" {>= "2.7"}
-  "astring" {>= "0.8.5"}
-  "sexplib" {>= "v0.14.0"}
-  "cmdliner" {>= "1.0.4"}
-  "dune-private-libs" {>= "2.8.0"}
-  "ocaml" {>= "4.11.0"}
-  "bos"
-  "fmt"
-  "opam-state" {>= opam-version}
-  "opam-format"
-  "odoc" {with-doc}
-]

--- a/opam-dune-lint.opam
+++ b/opam-dune-lint.opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.11.0"}
   "bos"
   "fmt"
-  "opam-state"
+  "opam-state" {>= opam-version}
   "opam-format"
   "odoc" {with-doc}
 ]

--- a/opam-dune-lint.opam.template
+++ b/opam-dune-lint.opam.template
@@ -1,14 +1,1 @@
 flags: plugin
-depends: [
-  "dune" {>= "2.7"}
-  "astring" {>= "0.8.5"}
-  "sexplib" {>= "v0.14.0"}
-  "cmdliner" {>= "1.0.4"}
-  "dune-private-libs" {>= "2.8.0"}
-  "ocaml" {>= "4.11.0"}
-  "bos"
-  "fmt"
-  "opam-state" {>= opam-version}
-  "opam-format"
-  "odoc" {with-doc}
-]

--- a/opam-dune-lint.opam.template
+++ b/opam-dune-lint.opam.template
@@ -1,1 +1,14 @@
 flags: plugin
+depends: [
+  "dune" {>= "2.7"}
+  "astring" {>= "0.8.5"}
+  "sexplib" {>= "v0.14.0"}
+  "cmdliner" {>= "1.0.4"}
+  "dune-private-libs" {>= "2.8.0"}
+  "ocaml" {>= "4.11.0"}
+  "bos"
+  "fmt"
+  "opam-state" {>= opam-version}
+  "opam-format"
+  "odoc" {with-doc}
+]


### PR DESCRIPTION
Following side-channel discussions.

In opam 2.1, opam-dune-lint won't work if it's compiled with opam-state 2.0.x, since it can't load an opam 2.1 root.

Ideally we'd want the opam libraries to match the client but `{= opam-version}` is not guaranteed to work. In the absence of semver operators, a lower-bound will do.

opam-dune-lint doesn't cause the state to be upgraded, so it is fine to install opam-dune-lint in opam 2.0 with the 2.1 client libraries - they do the upgrade "on the fly" so as long as nothing is written back to the root it won't be upgraded.