### PR TITLE
Support older versions of OCaml back to 4.10.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -16,7 +16,7 @@
   (sexplib (>= v0.14.0))
   (cmdliner (>= 1.0.4))
   (dune-private-libs (>= 2.8.0))
-  (ocaml (>= 4.11.0))
+  (ocaml (>= 4.10.0))
   bos
   fmt
   (opam-state (>= 2.1.0~~))

--- a/dune_project.ml
+++ b/dune_project.ml
@@ -33,7 +33,7 @@ let package_name =
   List.find_map (function
       | Dune_lang.List [Atom (A "name"); Atom (A name)] -> Some name
       | _ -> None
-    ) 
+    )
 
 let rec simplify_and = function
   | Dune_lang.List [Atom (A "and"); x] -> x

--- a/opam-dune-lint.opam
+++ b/opam-dune-lint.opam
@@ -13,7 +13,7 @@ depends: [
   "sexplib" {>= "v0.14.0"}
   "cmdliner" {>= "1.0.4"}
   "dune-private-libs" {>= "2.8.0"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.10.0"}
   "bos"
   "fmt"
   "opam-state" {>= "2.1.0~~"}


### PR DESCRIPTION
@talex5 Couldn't see any reason why this can't support older OCaml versions?
Trying 4.08 might even work on older, if they're worth supporting. 