### PR TITLE
Add quoted fix suggestion string.

### DIFF
--- a/tests/test_dune.t
+++ b/tests/test_dune.t
@@ -26,7 +26,7 @@ Create a simple dune project:
   $ touch main.ml test.ml
   $ dune build
 
-Replace all version numbers with "1.0" to get predictable outut.
+Replace all version numbers with "1.0" to get predictable output.
 
   $ export OPAM_DUNE_LINT_TESTS=y
 
@@ -34,9 +34,9 @@ Check that the missing libraries are detected:
 
   $ opam-dune-lint </dev/null
   test.opam: changes needed:
-    "fmt" {>= 1.0}                           [from /]
-    "bos" {with-test & >= 1.0}               [from /]
-    "opam-state" {with-test & >= 1.0}        [from /]
+    "fmt" {>= "1.0"}                         [from /]
+    "bos" {with-test & >= "1.0"}             [from /]
+    "opam-state" {with-test & >= "1.0"}      [from /]
   Note: version numbers are just suggestions based on the currently installed version.
   Run with -f to apply changes in non-interactive mode.
   [1]
@@ -45,9 +45,9 @@ Check that the missing libraries get added:
 
   $ opam-dune-lint -f
   test.opam: changes needed:
-    "fmt" {>= 1.0}                           [from /]
-    "bos" {with-test & >= 1.0}               [from /]
-    "opam-state" {with-test & >= 1.0}        [from /]
+    "fmt" {>= "1.0"}                         [from /]
+    "bos" {with-test & >= "1.0"}             [from /]
+    "opam-state" {with-test & >= "1.0"}      [from /]
   Note: version numbers are just suggestions based on the currently installed version.
   Wrote "dune-project"
 

--- a/tests/test_vendoring.t
+++ b/tests/test_vendoring.t
@@ -63,7 +63,7 @@ on "bos":
 
   $ opam-dune-lint </dev/null
   main.opam: changes needed:
-    "ocamlfind" {>= 1.0}                     [from lib]
+    "ocamlfind" {>= "1.0"}                   [from lib]
   Note: version numbers are just suggestions based on the currently installed version.
   Run with -f to apply changes in non-interactive mode.
   [1]

--- a/types.ml
+++ b/types.ml
@@ -34,8 +34,8 @@ module Change_with_hint = struct
       match c with
       | `Remove_with_test name -> Fmt.str "%a" pp_name name, ["(remove {with-test})"]
       | `Add_with_test name -> Fmt.str "%a {with-test}" pp_name name, ["(missing {with-test} annotation)"]
-      | `Add_build_dep dep -> Fmt.str "%a {>= %s}" pp_name (OpamPackage.name dep) (version_to_string dep), []
-      | `Add_test_dep dep -> Fmt.str "%a {with-test & >= %s}" pp_name (OpamPackage.name dep) (version_to_string dep), []
+      | `Add_build_dep dep -> Fmt.str "%a {>= \"%s\"}" pp_name (OpamPackage.name dep) (version_to_string dep), []
+      | `Add_test_dep dep -> Fmt.str "%a {with-test & >= \"%s\"}" pp_name (OpamPackage.name dep) (version_to_string dep), []
     in
     let hint =
       if Dir_set.is_empty dirs then hint


### PR DESCRIPTION
Fix for https://github.com/ocurrent/opam-dune-lint/issues/19.

Having the syntactically correct suggestion will be helpful when integrating with `ocurrent`and GH checks @talex5 