### PR TITLE
Restore compatibility with opam-state 2.0.x

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -20,5 +20,5 @@
   (ocaml (>= 4.10.0))
   (bos (>= 0.2.0))
   (fmt (>= 0.8.9))
-  (opam-state (>= 2.1.0~~))
+  (opam-state (>= 2.0.9))
   opam-format))

--- a/index.ml
+++ b/index.ml
@@ -16,10 +16,10 @@ let update_index t changes ~pkg =
 
 let create () =
   let root = OpamStateConfig.opamroot () in
-  ignore (OpamStateConfig.load_defaults root);
+  ignore (OpamStateConfig.load_defaults ~lock_kind:`Lock_read root);
   OpamGlobalState.with_ `Lock_none @@ fun gt ->
   let switch = OpamStateConfig.get_switch () in
-  let installed = (OpamSwitchState.load_selections gt switch).sel_installed in
+  let installed = (OpamSwitchState.load_selections ~lock_kind:`Lock_read gt switch).sel_installed in
   OpamPackage.Set.fold (fun pkg acc ->
       let changes = OpamPath.Switch.changes gt.root switch (OpamPackage.name pkg) in
       match OpamFile.Changes.read_opt changes with

--- a/opam-dune-lint.opam
+++ b/opam-dune-lint.opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "bos" {>= "0.2.0"}
   "fmt" {>= "0.8.9"}
-  "opam-state" {>= "2.1.0~~"}
+  "opam-state" {>= "2.0.9"}
   "opam-format"
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
It's a very minor tweak, but opam 2.0.9's libraries are built with the ability to load a 2.1.0 root, as long as it's loaded read-only. The two `?lock_kind` parameters here are present in opam-state 2.0.9 but not in 2.0.8 (and they default to write locks for backwards compatibility).