### PR TITLE
Add runtime_events to the list of libraries bundled with OCaml

### DIFF
--- a/main.ml
+++ b/main.ml
@@ -37,7 +37,7 @@ let to_opam ~index lib =
   match Astring.String.take ~sat:((<>) '.') lib with
   | "threads" | "unix" | "str" | "compiler-libs"
   | "bigarray" | "dynlink" | "ocamldoc" | "stdlib"
-  | "bytes" -> None          (* Distributed with OCaml *)
+  | "bytes" | "runtime_events" -> None          (* Distributed with OCaml *)
   | lib ->
     match Index.Owner.find_opt lib index with
     | Some pkg -> Some pkg


### PR DESCRIPTION
Otherwise, you get errors like this:
```
WARNING: can't find opam package providing "runtime_events"!
eio.opam: changes needed:
  "runtime_events" {>= "0"}                [from lib_eio/runtime_events]
```