### PR TITLE
Fix #59 parsing S-exp with sexplib is failing.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### unreleased
+- Fix the issue #59, Sexplib parse fails because of Dune stanza description quote( `"\|` or `"\>`). (@moyodiallo #60)
+
 ### v0.4
 
 - Fix the issue #53. Skip resolving a public library when it is added as optional dependency(dune's libraries stanza) (@moyodiallo #54).

--- a/tests/test_fix_bug_59.t
+++ b/tests/test_fix_bug_59.t
@@ -1,0 +1,53 @@
+Sexplib fails to parse `"\>` or `"\|`, those are finely parsed by dune. (issue #59) 
+opam-dune-lint does not need the description section.
+
+  $ cat > dune-project << EOF
+  > (lang dune 2.7)
+  > (generate_opam_files)
+  > (name dummy)
+  > 
+  > (package
+  >  (name dummy)
+  >  (description
+  >   "\> Dummy
+  >   ))
+  > EOF
+
+  $ dune build
+  $ opam-dune-lint -f 
+  dummy.opam: OK
+
+  $ cat > dune-project << EOF
+  > (lang dune 2.7)
+  > (generate_opam_files)
+  > (name dummy)
+  > 
+  > (package
+  >  (name dummy)
+  >  (description
+  >   "\> Dummy
+  >   "\| Dummy other
+  >   ))
+  > EOF
+
+  $ dune build
+  $ opam-dune-lint -f 
+  dummy.opam: OK
+
+  $ cat > dune-project << EOF
+  > (lang dune 2.7)
+  > (generate_opam_files)
+  > (name dummy)
+  > 
+  > (package
+  >  (name dummy)
+  >  (description
+  >   "\> Dummy
+  >   "\| Dummy other
+  >   "\> Dummy other
+  >   ))
+  > EOF
+
+  $ dune build
+  $ opam-dune-lint -f 
+  dummy.opam: OK


### PR DESCRIPTION
Fix the bug #59, the quote(`"\|` or `"\>`) of Dune stanza description, fails with sexplib.