### PR TITLE
Fix parsing of generate_opam_files stanzas

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 ### unreleased
+- Fix the issue #61, Dune stanza `(generate_opam_files true)` is same as `(generate_opam_files)` stanza (@devvydeebug #62).
+
 - Fix the issue #59, Sexplib parse fails because of Dune stanza description quote( `"\|` or `"\>`). (@moyodiallo #60)
 
 ### v0.4

--- a/dune_project.ml
+++ b/dune_project.ml
@@ -52,6 +52,7 @@ let parse () =
 let generate_opam_enabled =
   List.exists (function
       | Sexp.List [Sexp.Atom "generate_opam_files"; Atom v] -> bool_of_string v
+      | Sexp.List [Sexp.Atom "generate_opam_files"] -> true
       | _ -> false
     )
 


### PR DESCRIPTION
Fixes #61.

Adds handling for dune-project stanzas of the form `(generate_opam_files)`, which dune considers equivalent to `(generate_opam_files true)`. Before this, opam-dune-lint would edit the generated opam files directly, instead of editing dune-project, when encountering the simpler form.