### PR TITLE
fix: failing parse of `dune describe opam-files` output.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ### Unreleased
 
-- Fix the #66, when the content of dune-project file ends up with a comment, the Sexplib parse fails because the last `)` falls into the comment (@moyodiallo #67).
+- Fix the issue #66, when the content of dune-project file ends up with a comment, the Sexplib parse fails because the last `)` falls into the comment (@moyodiallo #67).
+
+- Fix the issue #68, with Sexp format dune parse quoted string by escaping "%{" to become "\%{" that OpamFile module can't parse. So we switch to Csexp format which doesn't change quoted string (@moyodiallo #69).
 
 ### v0.5
 

--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
 (executable
  (public_name opam-dune-lint)
  (name main)
- (libraries astring fmt fmt.tty bos opam-format opam-state cmdliner stdune sexplib str fpath))
+ (libraries astring fmt fmt.tty bos opam-format opam-state cmdliner stdune sexplib str fpath csexp))

--- a/dune_items.ml
+++ b/dune_items.ml
@@ -182,15 +182,15 @@ module Describe_opam_files = struct
   (** Representing a list of name and content of an opam file *)
   type t = (path * content) list
 
-  (** Decode opam files from the command "dune describe opam-files" output. *)
-  let opam_files_of_sexp = function
-    | Sexp.List sexps ->
+  (** Decode opam files from the command "dune describe opam-files --format csexp" output. *)
+  let opam_files_of_csexp = function
+    | Csexp.List sexps ->
       sexps
       |> List.map (function
-          | Sexp.List [Atom path; Atom content] ->
+          | Csexp.List [Atom path; Atom content] ->
             (path, content)
-          | s -> Fmt.failwith "%s is not a good format decoding an item" (Sexp.to_string s))
-    | s -> Fmt.failwith "%s is not a good format decoding items" (Sexp.to_string s)
+          | s -> Fmt.failwith "\"%s\" is not a good format decoding an item" (Csexp.to_string s))
+    | s -> Fmt.failwith "\"%s\" is not a good format decoding items" (Csexp.to_string s)
 
   let opamfile_of_content content = OpamFile.OPAM.read_from_string content
 

--- a/main.ml
+++ b/main.ml
@@ -11,7 +11,7 @@ let or_die = function
   | Ok x -> x
   | Error (`Msg m) -> failwith m
 
-let dune_describe_opam_files = Bos.Cmd.(v "dune" % "describe" % "opam-files")
+let dune_describe_opam_files = Bos.Cmd.(v "dune" % "describe" % "opam-files" % "--format" % "csexp")
 
 let () =
   (* When run as a plugin, opam helpfully scrubs the environment.
@@ -63,8 +63,8 @@ let get_opam_files () =
     ) Paths.empty
 
 let updated_opam_files_content () =
-  sexp dune_describe_opam_files
-  |> Dune_items.Describe_opam_files.opam_files_of_sexp
+  csexp dune_describe_opam_files
+  |> List.map Dune_items.Describe_opam_files.opam_files_of_csexp |> List.flatten
   |> List.fold_left (fun acc (path,opam) -> Paths.add path opam acc) Paths.empty
 
 let check_identical _path a b =

--- a/tests/test_fix_bug_68.t
+++ b/tests/test_fix_bug_68.t
@@ -45,8 +45,10 @@ Replace all version numbers with "1.0" to get predictable output.
 Check that the missing libraries get added:
 
   $ opam-dune-lint -f
-  opam-dune-lint: internal error, uncaught exception:
-                  At ./<none>:5:35-5:35::
-                  illegal escape sequence
-                  
-  [125]
+  test.opam: changes needed:
+    "fmt" {>= "1.0"}                         [from /]
+    "bos" {with-test & >= "1.0"}             [from /]
+    "opam-state" {with-test & >= "1.0"}      [from /]
+  Note: version numbers are just suggestions based on the currently installed version.
+  Wrote "./test.opam"
+  Warning in test: The package has a dune-project file but no explicit dependency on dune was found.

--- a/tests/test_fix_bug_68.t
+++ b/tests/test_fix_bug_68.t
@@ -1,0 +1,52 @@
+"dune describe opam-files" give an S-expression in which quoted string are escaped.
+the string "%{" is escaped with `\` to gives "\%{". And OpamFile fails parsing this
+output.
+
+
+  $ cat > dune-project << EOF
+  > (lang dune 2.7)
+  > (package
+  >  (name test)
+  >  (synopsis "Test package"))
+  > EOF
+
+  $ cat > test.opam << EOF
+  > # Preserve comments
+  > opam-version: "2.0"
+  > synopsis: "Test package"
+  > build: [
+  >   ["dune" "build"  "--use-libev" "%{conf-libev:installed}%" ]
+  > ]
+  > depends: [
+  >   "ocamlfind" {>= "1.0"}
+  >   "libfoo"
+  > ]
+  > EOF
+
+  $ cat > dune << EOF
+  > (executable
+  >  (name main)
+  >  (public_name main)
+  >  (modules main)
+  >  (libraries findlib fmt))
+  > (test
+  >  (name test)
+  >  (modules test)
+  >  (libraries bos opam-state))
+  > EOF
+
+  $ touch main.ml test.ml
+  $ dune build
+
+Replace all version numbers with "1.0" to get predictable output.
+
+  $ export OPAM_DUNE_LINT_TESTS=y
+
+Check that the missing libraries get added:
+
+  $ opam-dune-lint -f
+  opam-dune-lint: internal error, uncaught exception:
+                  At ./<none>:5:35-5:35::
+                  illegal escape sequence
+                  
+  [125]

--- a/types.ml
+++ b/types.ml
@@ -95,3 +95,14 @@ let sexp cmd =
       try Sexp.of_string s with
       | Sexp.Parse_error _ as e ->
         Fmt.epr "Error parsing '%s' output:\n" (Bos.Cmd.to_string cmd); raise e)
+
+let csexp cmd =
+  Bos.OS.Cmd.run_out (cmd)
+  |> Bos.OS.Cmd.to_string
+  |> or_die
+  |> String.trim
+  |> (fun s ->
+    match Csexp.parse_string_many s with
+    | Ok csexp -> csexp
+    | Error msg ->
+      Fmt.epr "Error parsing '%s' output:\n%S" (Bos.Cmd.to_string cmd) (snd msg); exit 1)


### PR DESCRIPTION
Fixes #68. It turns out by changing the format, sexp to csexp fixes the issue. The command now is `dune describe opam-files --format csexp`.