### PR TITLE
Fix terminating newlines in dune-project files

### DIFF
--- a/dune_project.ml
+++ b/dune_project.ml
@@ -155,7 +155,7 @@ let version t =
      | Some version -> version
 
 let dune_format dune =
-  Bos.OS.Cmd.(in_string dune |> run_io Bos.Cmd.(v "dune" % "format-dune-file") |> out_string)
+  Bos.OS.Cmd.(in_string dune |> run_io Bos.Cmd.(v "dune" % "format-dune-file") |> out_string ~trim:false)
   |> Bos.OS.Cmd.success
   |> or_die
 


### PR DESCRIPTION
Fixes the accidental trimming of terminating newlines from dune-project files, which was being performed as a default of the Bos library.